### PR TITLE
COOK-307 - openldap directory is defined as attribute, using attribute i...

### DIFF
--- a/recipes/auth.rb
+++ b/recipes/auth.rb
@@ -36,7 +36,7 @@ template "/etc/ldap.conf" do
   group "root"
 end    
 
-template "/etc/ldap/ldap.conf" do
+template "#{node.openldap.dir}/ldap.conf" do
   source "ldap-ldap.conf.erb"
   mode 0644
   owner "root"


### PR DESCRIPTION
...nstead of hardcoded path
