### PR TITLE
the directory /var/cache/local/preseeding does not exist

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -29,6 +29,11 @@ when "ubuntu"
       action :upgrade
     end
   end
+  directory "/var/cache/local/preseeding" do
+    mode 0755
+    owner "root"
+    group "root"
+  end
   cookbook_file "/var/cache/local/preseeding/slapd.seed" do
     source "slapd.seed"
     mode 0600 


### PR DESCRIPTION
at least in Ubuntu 12.04. Create it before attempting to stick files in there.
