### PR TITLE
added nil check in attributes/default.rb for attribute node['domain']

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 default['openldap']['basedn'] = "dc=localdomain"
 default['openldap']['server'] = "ldap.localdomain"
 
-if node['domain'].length > 0
+if node['domain'] && node['domain'].length > 0
   default['openldap']['basedn'] = "dc=#{node['domain'].split('.').join(",dc=")}"
   default['openldap']['server'] = "ldap.#{node['domain']}"
 end


### PR DESCRIPTION
When using this library simply as part of a dependency tree and not using any of the recipes inside provisioning fails with a nil error.
