### PR TITLE
Fix calling length on nil object

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 default['openldap']['basedn'] = "dc=localdomain"
 default['openldap']['server'] = "ldap.localdomain"
 
-if node['domain'] && !@node['domain'].empty?
+if node['domain'] && !node['domain'].empty?
   default['openldap']['basedn'] = "dc=#{node['domain'].split('.').join(",dc=")}"
   default['openldap']['server'] = "ldap.#{node['domain']}"
 end


### PR DESCRIPTION
Instead of just checking the length, check if the object is nil first, and then check and see if the string is emtpy
