### PR TITLE
fixing multiple notifies format for nsswitch.conf

### DIFF
--- a/recipes/auth.rb
+++ b/recipes/auth.rb
@@ -49,7 +49,8 @@ cookbook_file "/etc/nsswitch.conf" do
   owner "root"
   group "root"
   notifies :restart, "service[nscd]", :immediately
-  notifies :run, ["execute[nscd-clear-passwd]", "execute[nscd-clear-group]"], :immediately
+  notifies :run, "execute[nscd-clear-passwd]", :immediately
+  notifies :run, "execute[nscd-clear-group]", :immediately
 end
 
 %w{ account auth password session }.each do |pam|


### PR DESCRIPTION
current version of chef (client 11.6.0, server 11.0.8) do not appear to like the having multiple notifies specified as a list.

as a result I've broken these out into multiple lines
