### PR TITLE
Service enable/start resource moved to end.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -62,10 +62,6 @@ if node['openldap']['tls_enabled'] && node['openldap']['manage_ssl']
   end
 end
 
-service "slapd" do
-  action [:enable, :start]
-end
-
 if (node['platform'] == "ubuntu")
   template "/etc/default/slapd" do
     source "default_slapd.erb"
@@ -115,3 +111,8 @@ else
     notifies :restart, "service[slapd]"
   end
 end
+
+service "slapd" do
+  action [:enable, :start]
+end
+


### PR DESCRIPTION
Potentially corrupted slapd.conf would interupt service start and thus cooking. Without manual intervention it's not possible to recover using chef. Postponed start to the time when all .conf files are re/created solves the issue.
