### PR TITLE
Add RHEL/CentOS 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           - 'debian-9'
           - 'debian-10'
           - 'centos-7'
+          - 'centos-8'
           - 'fedora-latest'
           - 'ubuntu-1604'
           - 'ubuntu-1804'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the openldap cookbook.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Add RHEL/CentOS 8 support
+
 ## 4.2.0 (2020-11-04)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 - Ubuntu
 - Debian
 - FreeBSD
-- RHEL/CentOS ~> 7.0 *NOTE: RHEL 8 [removed support](https://www.redhat.com/en/blog/preparing-identity-management-red-hat-enterprise-linux-8) for openldap*
+- RHEL/CentOS >= 7.0 *NOTE: RHEL 8 [removed support](https://www.redhat.com/en/blog/preparing-identity-management-red-hat-enterprise-linux-8) for openldap. We provide support via a repository provided by the [OSUOSL](https://osuosl.org).*
 - Fedora
 - openSUSE Leap
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -37,6 +37,13 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup
 
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup
+
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,6 +14,7 @@ verifier:
 platforms:
   - name: amazonlinux-2
   - name: centos-7
+  - name: centos-8
   - name: debian-9
   - name: debian-10
   - name: fedora-latest

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -32,6 +32,18 @@ action :install do
     end
   end
 
+  # NOTE(ramereth): RHEL 8 doesn't include openldap-servers so we pull from the
+  # OSUOSL which builds the latest Fedora release for EL8
+  if platform_family?('rhel') && node['platform_version'].to_i >= 8
+    yum_repository 'osuosl-openldap' do
+      baseurl 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openldap/$basearch'
+      gpgkey 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+      description 'OSUOSL OpenLDAP repository'
+      gpgcheck true
+      enabled true
+    end
+  end
+
   package server_package do
     response_file 'slapd.seed' if platform_family?('debian')
     action new_resource.package_action
@@ -57,7 +69,7 @@ action_class do
     when 'debian'
       'db-util'
     when 'rhel', 'amazon'
-      'compat-db47'
+      'compat-db47' if node['platform_version'].to_i < 8
     when 'freebsd'
       'libdbi'
     end


### PR DESCRIPTION
RHEL 8 doesn't include openldap-servers so we pull from the OSUOSL which builds
the latest Fedora release for EL8. Also fix issue where EL8 doesn't include a db
package.

Signed-off-by: Lance Albertson <lance@osuosl.org>
