### PR TITLE
Enable unified_mode for Chef 17 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           - 'centos-7'
           - 'centos-8'
           - 'fedora-latest'
-          - 'ubuntu-1604'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
           - 'opensuse-leap-15'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Enable `unified_mode` for Chef 17 compatiblity
+
 ## 5.0.1 - *2021-06-01*
 
 ## 5.0.0 - *2020-12-14*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-- Chef 12.15+
+- Chef 15.3+
 
 ### Cookbooks
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -49,13 +49,6 @@ platforms:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-16.04
-    driver:
-      image: dokken/ubuntu-16.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   product_name: chef
+  chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -18,8 +19,8 @@ platforms:
   - name: debian-9
   - name: debian-10
   - name: fedora-latest
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: freebsd-12
 
 suites:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs and configures OpenLDAP (slapd) an open source imple
 version           '5.0.1'
 source_url        'https://github.com/sous-chefs/openldap'
 issues_url        'https://github.com/sous-chefs/openldap/issues'
-chef_version      '>= 12.15'
+chef_version      '>= 15.3'
 
 supports 'amazon'
 supports 'centos'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,3 +1,5 @@
+unified_mode true
+
 property :package_action, Symbol, default: :install
 property :install_client, [true, false], default: true, description: 'Install openldap client package(s)'
 property :install_server, [true, false], default: true, description: 'Install openldap server package(s)'


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

Chef 17 requires resources to enable `unified_mode` in preparation for Chef 18.

## Issues Resolved

(none)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
