### PR TITLE
Allow to toggle RPM repo configuration on openldap_install resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+Allow to toggle OSUSOL RPM repo configuration on openldap_install resource
+
 ## 6.0.13 - *2023-04-07*
 
 Standardise files with files in sous-chefs/repo-management

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ end
 
 # package settings
 default['openldap']['package_install_action'] = :install
+default['openldap']['package_install_repository'] = true
 
 #
 # openldap configuration (generally overwritten by the user)

--- a/documentation/resource_openldap_install.md
+++ b/documentation/resource_openldap_install.md
@@ -4,11 +4,12 @@ Install client and server packages for OpenLDAP
 
 ## Properties
 
-| Name             | Type    | Default    | Description                        |
-| ---------------- | ------- | ---------- | ---------------------------------- |
-| `package_action` | Symbol  | `:install` | Package action to use              |
-| `install_client` | Boolean | `true`     | Install openldap client package(s) |
-| `install_server` | Boolean | `true`     | Install openldap server package(s) |
+| Name                 | Type    | Default    | Description                                             |
+| -------------------- | ------- | ---------- | ------------------------------------------------------- |
+| `package_action`     | Symbol  | `:install` | Package action to use                                   |
+| `install_client`     | Boolean | `true`     | Install openldap client package(s)                      |
+| `install_server`     | Boolean | `true`     | Install openldap server package(s)                      |
+| `install_repository` | Boolean | `true`     | Install extra repository for client & server package(s) |
 
 ### Examples
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 openldap_install 'Install packages' do
   package_action node['openldap']['package_install_action']
+  install_repository node['openldap']['package_install_repository']
 end
 
 template openldap_defaults_path do

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -3,6 +3,7 @@ unified_mode true
 property :package_action, Symbol, default: :install
 property :install_client, [true, false], default: true, description: 'Install openldap client package(s)'
 property :install_server, [true, false], default: true, description: 'Install openldap server package(s)'
+property :install_repository, [true, false], default: true, description: 'Install extra repository for client & server package(s)'
 
 action :install do
   package openldap_db_package do
@@ -34,7 +35,7 @@ action :install do
 
   # NOTE(ramereth): RHEL 8 doesn't include openldap-servers so we pull from the
   # OSUOSL which builds the latest Fedora release for EL8
-  if platform_family?('rhel') && node['platform_version'].to_i >= 8
+  if new_resource.install_repository && platform_family?('rhel') && node['platform_version'].to_i >= 8
     yum_repository 'osuosl-openldap' do
       baseurl 'https://ftp.osuosl.org/pub/osl/repos/yum/$releasever/openldap/$basearch'
       gpgkey 'https://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'


### PR DESCRIPTION

# Description

On RHEL >= 8 the resource is configuring the OSUSOL repository to support openldap-server install.
However in some cases you may not need this specific repository.

Now by setting `install_repository false` on the resource, the repo won't be installed.
Also the `openldap.package_install_repository` attributes allow to control the value set to this property in the openldap::default recipe.

Default behaviour is preserved, and RHEL >= 8 servers will continue to install the repository.

## Issues Resolved

None created.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
