### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependencies
 
 ## Build and Test System
 
@@ -27,7 +27,7 @@
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb      # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 name 'openldap'
-default_source :supermarket
 
 run_list 'test::default'
 
 cookbook 'openldap', path: '.'
 cookbook 'test', path: './test/cookbooks/test'
+cookbook 'dpkg_autostart', git: 'https://github.com/sous-chefs/dpkg_autostart.git', branch: 'main'
 
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'openldap'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'openldap', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,16 +27,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  tls_enabled: &tls_enabled_run_list
-    - recipe[test::ssl]
-  type_provider: &type_provider_run_list
-    - recipe[test::provider]
-  type_consumer: &type_consumer_run_list
-    - recipe[test::consumer]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -53,14 +43,13 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
     verifier: *default_verifier
   - name: tls-enabled
-    run_list: *tls_enabled_run_list
+    named_run_list: ssl
     verifier: *tls_enabled_verifier
   - name: type-provider
-    run_list: *type_provider_run_list
+    named_run_list: provider
     verifier: *type_provider_verifier
   - name: type-consumer
-    run_list: *type_consumer_run_list
+    named_run_list: consumer
     verifier: *type_consumer_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Description

Migrates cookbook dependency management from Berkshelf to Policyfile.

## Changes

- Add `Policyfile.rb`
- Remove `Berksfile`
- Switch ChefSpec setup from `chefspec/berkshelf` to `chefspec/policyfile`
- Update Copilot setup and instructions to run `chef install Policyfile.rb`
- Remove stale Berksfile ignore entries

## Verification

- `chef install Policyfile.rb`
- `cookstyle --no-server --cache-root /private/tmp/rubocop_cache`
- `/opt/homebrew/bin/markdownlint-cli2 "**/*.md"`
- `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec`
- `git diff --check`
- `kitchen list`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`
